### PR TITLE
Naff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -928,7 +928,7 @@ endif()
 
 if(NAFF)
 	find_path(FFTW3_INCLUDE_DIR fftw3.h fftw.h)
-	find_library(FFTW3_LIBRARIES NAMES fftw3 libfftiw3 fftw)
+	find_library(FFTW3_LIBRARIES NAMES libfftw3.a fftw3  fftw)
 	if(NOT FFTW3_INCLUDE_DIR OR NOT FFTW3_LIBRARIES)
 		message(FATAL_ERROR "Could not find fftw3.")
 	endif()
@@ -937,7 +937,8 @@ if(NAFF)
 	message(STATUS "Include dirs of boost: " ${Boost_INCLUDE_DIRS} )
 	message(STATUS "Libs of boost: " ${Boost_LIBRARIES} )
 	
-	include_directories( ${FFTW3_INCLUDES} )
+	include_directories( ${FFTW3_INCLUDES} ${Boost_INCLUDE_DIRS})
+        LINK_LIBRARIES(${Boost_LIBRARIES} ${FFTW3_LIBRARIES})
 	
 	file(GLOB NAFF_SOURCES ${CMAKE_SOURCE_DIR}/SixTrack/naff/*.cpp ${CMAKE_SOURCE_DIR}/SixTrack/naff/*.cc)
 	add_library(naff STATIC ${NAFF_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,8 +937,7 @@ if(NAFF)
 	message(STATUS "Include dirs of boost: " ${Boost_INCLUDE_DIRS} )
 	message(STATUS "Libs of boost: " ${Boost_LIBRARIES} )
 	
-	include_directories( ${FFTW3_INCLUDES} ${Boost_INCLUDE_DIRS})
-        LINK_LIBRARIES(${Boost_LIBRARIES} ${FFTW3_LIBRARIES})
+	include_directories( ${FFTW3_INCLUDES} ) 
 	
 	file(GLOB NAFF_SOURCES ${CMAKE_SOURCE_DIR}/SixTrack/naff/*.cpp ${CMAKE_SOURCE_DIR}/SixTrack/naff/*.cc)
 	add_library(naff STATIC ${NAFF_SOURCES})

--- a/SixTrack/naff/naff_interface.cpp
+++ b/SixTrack/naff/naff_interface.cpp
@@ -1,15 +1,13 @@
 #include "NAFF.h"
 #include <iostream>
 
-extern "C" double tunenaff_(double* x,  double* xp, int* maxn, int* x_len, int* xp_len) {
+extern "C" double tunenaff_(double* x,  double* xp, int* maxn) {
 
   // Don't mix buffers with Fortran (make sure to flush before calling this code too)
   std::cout << std::flush;
   
   // For debugging of argument passing.
   // std::cout << "**TUNENAFF**" << std::endl << std::flush;
-  // std::cout << "x_len  = " << *x_len  << std::endl;
-  // std::cout << "xp_len = " << *xp_len << std::endl;
   // std::cout << "maxn   = " << *maxn   << std::endl << std::flush;
   // Flush before these memory accesses...
   // std::cout << "x[0]="  << x[0] << std::endl << std::flush;
@@ -19,16 +17,6 @@ extern "C" double tunenaff_(double* x,  double* xp, int* maxn, int* x_len, int* 
   // Input sanity checks
   if (maxn <= 0) {
     fprintf(stderr, "CRITICAL ERROR in double tunenaff_(...): maxn = %d <= 0", *maxn);
-    exit(EXIT_FAILURE);
-  }
-  if ((*x_len > 0 and *xp_len > 0) and (*x_len < *maxn or *xp_len < *maxn)) {
-    //In some cases, no x_len and xp_len is passed (they are set to 0);
-    //then just hope maxn is OK. If not, check the lengths!
-    fprintf(stderr, "CRITICAL ERROR in double tunenaff_(...): maxn is bigger than x_len or xp_len.");
-    exit(EXIT_FAILURE);
-  }
-  if (*x_len != *xp_len) {
-    fprintf(stderr, "CRITICAL ERROR in double tunenaff_(...): x_len is different than xp_len.");
     exit(EXIT_FAILURE);
   }
 
@@ -46,6 +34,10 @@ extern "C" double tunenaff_(double* x,  double* xp, int* maxn, int* x_len, int* 
   NAFF naff;
   double tune = naff.get_f1(data,data_prime);
 
+  // FFTW library returns tune from 0-0.5
+  if (tune<0.1)
+    tune = 1.0-tune;
+  
   //More Debugging stuff..
   // std::cout << "tune = " << tune << std::endl;
   


### PR DESCRIPTION
Changes:
-The search for the first estimation of the peak frequency is done both in the positive and negative side of the spectrum. When physical coordinates are used the amplitudes of the frequencies are mirrored but this is not the case in normalised coordinates.

-x_len and xp_len caused a segmentation fault in my case and they are removed

-The FFTW3 library returns frequencies from 0 to 0.5 so there is no need for the 1-tune part in sixtrack.s for the synchrotron tune. I added the part 1-tune in the naff_interface.cpp code in order not to change anything in sixtrack.s.